### PR TITLE
remove rserve from the package dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Imports:
     Hmisc,
     jsonlite,
     ncdf4,
-    Rserve,
     scales,
     tidyr
 Suggests:


### PR DESCRIPTION
The ghgvcR package itself does not require Rserve; we're just using Rserve to make the package's functions available as a service. This is a runtime concern addressed in the Dockerfile steps.
