### PR TITLE
Check for NA symbol

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -241,7 +241,8 @@ remap_range <- function(input, input_min, input_max, output_min, output_max) {
 #'   str2LogicalOrNumeric("NaN") # -> "NaN"
 #' }
 str2LogicalOrNumeric <- function(string) {
-  if (string == "") x <- NA
+  if (is.na(string)) x <- NA
+  else if (string == "") x <- NA
   else if (string == "NA") x <- NA
   else if (string == "null") x <- NA
   else if (string == "NaN") x <- NaN


### PR DESCRIPTION
The rserve-client library used by Ruby appears to be converting "NA" the
string into the native R symbol, NA. This behavior causes the branching
condition, fixed in this PR, to break otherwise

Tested by calling the function with any variation of "NA" as an argument