### PR TITLE
Add missing docker dependencies and resolve permissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ language: R
 sudo: false
 cache: packages
 
-
 addons:
   apt:
     packages:
       - libnetcdf-dev
       - libudunits2-dev
       - netcdf-bin
+      - libnetcdf-dev
+      - libxml2
+      - libxml2-dev
+      - libssl-dev

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ Imports:
     ncdf4,
     scales,
     tidyr,
-    XML
+    XML,
+    rmarkdown
 Suggests:
     knitr,
     readr,

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,20 @@ RUN useradd --create-home --home-dir $HOME ghgvcr \
 # install distro libraries for R dependencies
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
-		libnetcdf-dev \
+		libnetcdf-dev libxml2 libxml2-dev libssl-dev \
 	&& rm -rf /var/lib/apt/lists/*
+
+# Set workdir & user early in the application, so that all libs are installed
+# as ghgvcr user, rather than as root
+WORKDIR $HOME
+USER ghgvcr
+
+# Create a lib folder under the ghgvcr $HOME, so the ghgvcr user has the ability
+# to write to it. Useful later if we need to install libs for testing
+RUN mkdir -p /home/ghgvcr/lib
+
+# Set the R lib path for the user. All R libs will be installed here
+ENV R_LIBS_USER /home/ghgvcr/lib
 
 # install R dependency packages
 RUN Rscript -e "install.packages(c('ggplot2', 'gridExtra', 'Hmisc', 'jsonlite', 'scales', 'tidyr', 'ncdf4', 'Rserve', 'XML'), repos = 'http://cran.us.r-project.org')"
@@ -21,9 +33,6 @@ COPY . $HOME
 
 # install our project packages
 RUN Rscript -e "install.packages('$HOME', repos=NULL, type='source')"
-
-WORKDIR $HOME
-USER ghgvcr
 
 EXPOSE 6311
 

--- a/R/ghgvc.R
+++ b/R/ghgvc.R
@@ -166,9 +166,16 @@ calc_ghgv <- function(eco,
       
       #Disturbance, Dx, Eq. 6:
       #First the flux disturbance
-      flux_disturb <- c(1:disturb_years, 
-                        rep(disturb_years, 
-                            num_years_emissions - 1)) *
+      
+      # this was giving warnings
+      # flux_disturb <- c(1:disturb_years, 
+      #                   rep(disturb_years, 
+      #                       num_years_emissions - 1)) *
+      #   t(ghg_params['FR',] - t(flux))
+      
+      # I fixed the warning like that
+      
+      flux_disturb <- c(0:(disturb_years-1),disturb_years:num_years_emissions) *
         t(ghg_params['FR',] - t(flux))
       
       #storage disturbance

--- a/vignettes/getting_started.Rmd
+++ b/vignettes/getting_started.Rmd
@@ -16,9 +16,9 @@ Citation: Kristina J. Teixeira and Evan H. Delucia 2011. The greenhouse gas valu
 ####Overview
 `ghgvcR` has several principal functions:
 
-1. `get_biome()` determines the biomes available at a given latitude and longitude. 
+1. `get_biome()` determines the biomes available at a given latitude and longitude.
 1. `get_ncdf()` reads in netcdf biome data for a given latitude and longitude.
-2. `calc_ghgv()` calculates the greenhouse gas emissions of a specific ecosystem. 
+2. `calc_ghgv()` calculates the greenhouse gas emissions of a specific ecosystem.
 3. `plot_ghgv()` creates plots of greenhouse gas emissions seen on the GHGVC app.
 
 `ghgvcR` talks to the GHGVC web app by receiving json parameters and passing back json results. However it also works as a stand alone estimator of greenhouse gas emissions at a specific location.
@@ -31,10 +31,11 @@ library(ghgvcr)
 
 #load example config data
 config_file <- system.file("config/multi_site.xml", package = "ghgvcr")
-config <- XML::xmlToList(XML::xmlParse(config_file))  
+config <- XML::xmlToList(XML::xmlParse(config_file))
 
-#Calculate 
+#Calculate
 #res <- calc_ghgv(config, write_data=FALSE, make_plots=FALSE)
+res <- ghgvc(config, write_data=FALSE, make_plots=FALSE)
 
 #Write the data to a file:
 #outdir <- "./"
@@ -50,11 +51,11 @@ config <- XML::xmlToList(XML::xmlParse(config_file))
 
 ```
 
-####Biome Example 
+####Biome Example
 The same calculation can be done for a specific location if biome data is available.
 
 ```{r eval=FALSE}
-#NOT RUN 
+#NOT RUN
 library(ghgvcr)
 data(biome_defaults)
 


### PR DESCRIPTION
Setting the user & lib paths in the attached fixes permissions errors
when shelling into container and trying to run things (like install
other dependencies for running tests)

Also leverages a shared library path implemented in the compose file in
the rubyforgood/ghgvc repo

The xml/ssl depedencies installed are required for the R XML library
to function correctly