### PR TITLE
Add rmarkdown as dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p /home/ghgvcr/lib
 ENV R_LIBS_USER /home/ghgvcr/lib
 
 # install R dependency packages
-RUN Rscript -e "install.packages(c('ggplot2', 'gridExtra', 'Hmisc', 'jsonlite', 'scales', 'tidyr', 'ncdf4', 'Rserve', 'XML'), repos = 'http://cran.us.r-project.org')"
+RUN Rscript -e "install.packages(c('rmarkdown', 'ggplot2', 'gridExtra', 'Hmisc', 'jsonlite', 'scales', 'tidyr', 'ncdf4', 'Rserve', 'XML'), repos = 'http://cran.us.r-project.org')"
 
 # place the ghgvcR project into the image
 COPY . $HOME


### PR DESCRIPTION
The docker image failed to build/load per commands David shared without
this dependency included.

Build image & drop into a shell

    docker build -t ghgvcr .
    docker run --rm -it ghgvcr bash

From inside the container shell:

    R # starts R shell
    install.packages("devtools")
    # Change this path to actual ghvcr path. i think it may be /app/ghgvcr
    devtools::check("path/to/ghgvcR")