### PR TITLE
Logic fix for barren exclusion

### DIFF
--- a/R/biome.R
+++ b/R/biome.R
@@ -372,11 +372,11 @@ get_biome <- function(latitude,
       biome_default$latent <- (res$global_potVeg_latent_num -
                                  res$global_bare_latent_heat_flux_num) / 51007200000*1000000000
       biome_default$biophysical_net <- biome_default$latent
-    }
-    if(vegtypes == "Barren") {
-      biome_default$sw_radiative_forcing <- 0
-      biome_default$latent <- 0
-      biome_default$biophysical_net <- 0
+      if(vegtypes[[i]] == "Barren") {
+        biome_default$sw_radiative_forcing <- 0
+        biome_default$latent <- 0
+        biome_default$biophysical_net <- 0
+      }
     }
     else {
       biome_default$sw_radiative_forcing <- 0


### PR DESCRIPTION
Nest `barren` check in `ibis_vegtypes` check.